### PR TITLE
Differentiate link buttons from non-interactive skill/concept tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
                 <div class="project-section">
                     <h3 class="section-label">Links:</h3>
                     <div class="links-group">
-                        <a href="#" class="link-item">Web App</a>
-                        <a href="#" class="link-item">GitHub Repo</a>
+                        <a href="#" class="link-item"><i class="fas fa-arrow-up-right-from-square"></i> Web App</a>
+                        <a href="#" class="link-item"><i class="fas fa-arrow-up-right-from-square"></i> GitHub Repo</a>
                     </div>
                 </div>
                 <div class="project-section">
@@ -84,8 +84,8 @@
                 <div class="project-section">
                     <h3 class="section-label">Links:</h3>
                     <div class="links-group">
-                        <a href="#" class="link-item">Dashboard</a>
-                        <a href="#" class="link-item">GitHub Repo</a>
+                        <a href="#" class="link-item"><i class="fas fa-arrow-up-right-from-square"></i> Dashboard</a>
+                        <a href="#" class="link-item"><i class="fas fa-arrow-up-right-from-square"></i> GitHub Repo</a>
                     </div>
                 </div>
                 <div class="project-section">
@@ -126,8 +126,8 @@
                 <div class="project-section">
                     <h3 class="section-label">Links:</h3>
                     <div class="links-group">
-                        <a href="#" class="link-item">Web App (coming soon)</a>
-                        <a href="#" class="link-item">GitHub Repo</a>
+                        <a href="#" class="link-item"><i class="fas fa-arrow-up-right-from-square"></i> Web App (coming soon)</a>
+                        <a href="#" class="link-item"><i class="fas fa-arrow-up-right-from-square"></i> GitHub Repo</a>
                     </div>
                 </div>
                 <div class="project-section">

--- a/styles.css
+++ b/styles.css
@@ -211,7 +211,9 @@ body {
 }
 
 .link-item {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     padding: 8px 16px;
     background-color: var(--primary-lighter);
     color: var(--primary-color);
@@ -221,6 +223,7 @@ body {
     font-size: 0.9rem;
     transition: var(--transition);
     border: 2px solid var(--primary-light);
+    cursor: pointer;
 }
 
 .link-item:hover {
@@ -249,21 +252,10 @@ body {
     white-space: nowrap;
 }
 
-.tag:hover {
-    border-color: var(--primary-light);
-    color: var(--primary-color);
-    background-color: var(--primary-lighter);
-}
-
 .tag.concept {
     background-color: #f0f7e0;
     border-color: var(--primary-light);
     color: var(--primary-color);
-}
-
-.tag.concept:hover {
-    background-color: var(--primary-light);
-    color: white;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary
- Convert `.link-item` to `inline-flex` with `align-items`, `gap`, and `cursor: pointer` to reinforce interactivity
- Add external-link icon (`fa-arrow-up-right-from-square`) to all 6 project link anchors
- Remove false-affordance hover effects from `.tag` and `.tag.concept` spans

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)